### PR TITLE
Fix crash when using with `Moose::GetoptX`

### DIFF
--- a/lib/IO/Prompt/Tiny.pm
+++ b/lib/IO/Prompt/Tiny.pm
@@ -47,7 +47,7 @@ sub prompt {
 sub _is_interactive {
     my ($out_handle) = ( @_, select );
     return 0 if not -t $out_handle;
-    if ( tied(*ARGV) or defined( fileno(ARGV) ) ) {
+    if ( tied(*ARGV) or defined( fileno(*::ARGV) ) ) {
         return -t *STDIN if defined $ARGV && $ARGV eq '-';
         return @ARGV > 0 && $ARGV[0] eq '-' && -t *STDIN if eof *ARGV;
         return -t *ARGV;


### PR DESCRIPTION
Certain usages of this module with `Moose::GetoptX` result in dying with

```
Can't use an undefined value as a symbol reference
```

Unfortunately, I don't have a small enough testcase for this. It's possible we are doing something funky, but this fixes our problem and shouldn't affect anything else methinks?

Thanks!